### PR TITLE
Backpress navigation fix

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,9 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity
+            android:launchMode="singleTask"
+            android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/unlimitedcoffee/LoginActivity.java
+++ b/app/src/main/java/com/unlimitedcoffee/LoginActivity.java
@@ -18,6 +18,10 @@ public class LoginActivity extends AppCompatActivity {
     TextView mTextViewRegister;
     DatabaseHelper db;
 
+    @Override
+    public void onBackPressed() {
+        moveTaskToBack(true);
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -63,4 +67,5 @@ public class LoginActivity extends AppCompatActivity {
             }
         });
     }
+
 }

--- a/app/src/main/java/com/unlimitedcoffee/RegisterActivity.java
+++ b/app/src/main/java/com/unlimitedcoffee/RegisterActivity.java
@@ -25,6 +25,10 @@ public class RegisterActivity extends AppCompatActivity {
     Button mRegisterButton;
     DatabaseHelper db;
 
+    @Override // prevent backpress from launching main smsapp activity
+    public void onBackPressed() {
+        moveTaskToBack(true);
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -11,7 +11,7 @@
         android:id="@+id/edittext_username"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="150dp"
+        android:layout_marginTop="170dp"
         android:hint="@string/phone_number"
         android:inputType="number"/>
 
@@ -20,13 +20,15 @@
         android:inputType="textPassword"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:hint="@string/password"/>
 
     <Button
         android:id="@+id/login_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/login"/>
+        android:layout_marginTop="8dp"
+        android:text="@string/login" />
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -36,12 +38,15 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/not_registered"/>
+            android:layout_marginTop="8dp"
+            android:text="@string/not_registered" />
         <TextView
             android:id="@+id/textview_register"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
             android:paddingLeft="5dp"
+            android:textColor="@color/colorAccent2"
             android:text="@string/register"/>
 
     </LinearLayout>

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -20,23 +20,28 @@
         android:inputType="textPassword"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:hint="@string/password"/>
     <EditText
         android:id="@+id/edittext_cf_password"
         android:inputType="textPassword"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:hint="@string/confirm_password"/>
 
     <Button
         android:id="@+id/register_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:text="@string/register_button"/>
+
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/phone_number_hint"/>
+        android:layout_marginTop="7dp"
+        android:text="@string/phone_number_hint" />
 
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#3F51B5</color>
     <color name="colorPrimaryDark">#303F9F</color>
     <color name="colorAccent">#FF4081</color>
+    <color name='colorAccent2'>#22aa22</color> // green for Register link
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="password">Password</string>
     <string name="login">login</string>
     <string name="not_registered">Not registered?</string>
-    <string name="register">Register</string>
+    <string name="register">Register here.</string>
     <string name="confirm_password">Confirm Password</string>
     <string name="register_button">Register</string>
     <string name="remove_account">REMOVE ACCOUNT</string>


### PR DESCRIPTION
A few updates to fix the navigation issue where user could backpress into main activity window. Added singleTask launchMode, overrode the backpress action for Login and Register activities. 
Also made a couple of tweaks to text spacing on Login and Register layouts, and updated "Register" link on login page to green, and now reads "Register Here". Can skip the tweaks if you prefer, no biggie.